### PR TITLE
DVO Validation Updates

### DIFF
--- a/openshift/openshift-acme.template.yaml
+++ b/openshift/openshift-acme.template.yaml
@@ -87,6 +87,9 @@ objects:
     name: openshift-acme
     labels:
       app: openshift-acme
+    annotations:
+      email: ${OWNER_EMAIL}
+      owner: ${OWNER_NAME}
   spec:
     selector:
       matchLabels:
@@ -146,3 +149,7 @@ parameters:
   value: 100m
 - name: MEMORY_LIMITS
   value: 100Mi
+- name: OWNER_EMAIL
+  value: owner@example.com
+- name: OWNER_NAME
+  value: example-owner

--- a/openshift/openshift-acme.template.yaml
+++ b/openshift/openshift-acme.template.yaml
@@ -123,6 +123,22 @@ objects:
             limits:
               cpu: ${CPU_LIMITS}
               memory: ${MEMORY_LIMITS}
+          livenessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - "ps -A | grep openshift-acme"
+            initialDelaySeconds: 10
+            periodSeconds: 60
+          readinessProbe:
+            exec:
+              command:
+              - /bin/sh
+              - -c
+              - "ps -A | grep openshift-acme"
+            initialDelaySeconds: 10
+            periodSeconds: 60
 - kind: ConfigMap
   apiVersion: v1
   metadata:


### PR DESCRIPTION
This PR attempts to fix DVO validation errors for openshift-acme resources. Not all of the validations are fixable, and careful thought must be applied to consider if the applied fixes are valuable or not. I am looking for feedback and the team's thoughts on how to proceed with these changes. 

| check  | notes |
|---|---|
|  deprecated_service_account_field | serviceAccountName is replaced with serviceAccount at the kube-api level. oc process does not mutate the serviceAccountName key, so the mutation must be in kube itself. @bkez322's pr to kube-linter should resolve this issue. |
| minimum_three_replicas  |  This check should not apply for this deployment. Only a single replica is necessary to provide the controller functionality.  |
| no_liveness_probe  | This is a point of debate for me. Liveness and readiness probes should be implemented at the controller level and exposed to those implementing the controller such that they can add it to their manifests. The check I added looks for the presence of the controller executable, but can not tell if the controller is working. I debate whether or not this probe is useful, and want to open it up for discussion. |
|  non_existent_service_account | Failing this check is a side-effect of statically analyzing k8s objects running on a live cluster without considering dependent objects..  |
| no_readiness_probe | Same debate as "no_liveness_probe" |
| no_read_only_root_fs | SCC is an OpenShift concept - workloads are bound by SCC's, and kube-linter does not have knowledge of SCCs. Given workloads on OpenShift are bound by SCC, I do not think this check is valuable. |
| required_annotation_email | Straightforward to implement and add, but requires ensuring that all dependent deployments of openshift-acme-controller have the required fields applied in their respective saas files. |
| required_label_owner | Same as email. |